### PR TITLE
Refactor: Centralize CORS configuration in Spring Security

### DIFF
--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/AgendaController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/AgendaController.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/rest/agenda")
-@CrossOrigin(origins = "http://localhost:3000")
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Agendamentos", description = "Operações relacionadas a agendamentos de serviços") // <<< TAG ATUALIZADA
 public class AgendaController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/ClienteRelatorioController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/ClienteRelatorioController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/rest/relatorios/cliente") // <<< Novo RequestMapping base para relatórios de cliente
-@CrossOrigin(origins = "http://localhost:3000")
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Relatórios Cliente", description = "Endpoints para gerar relatórios específicos de clientes") // <<< Nova Tag
 public class ClienteRelatorioController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/ClientesController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/ClientesController.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/rest/clientes") // Mapping base permanece o mesmo
-@CrossOrigin(origins = "http://localhost:3000")
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Clientes", description = "Gerenciamento de clientes e seus dados associados")
 public class ClientesController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/IaController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/IaController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/rest/ia")
-@CrossOrigin(origins = "http://localhost:3000")
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "IA Service", description = "Endpoint para interação com a IA Generativa (Google Gemini)") // Descrição um pouco mais específica
 public class IaController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/OficinaController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/OficinaController.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/rest/oficina")
-@CrossOrigin(origins = "http://localhost:3000")
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Oficina (Diagnósticos)", description = "Operações relacionadas aos registros de diagnóstico da oficina") // <<< TAG ADICIONADA
 public class OficinaController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/OrcamentoController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/OrcamentoController.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/rest/orcamentos")
-@CrossOrigin(origins = "http://localhost:3000")
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Orçamentos", description = "Operações relacionadas a orçamentos de serviços")
 public class OrcamentoController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/PagamentoController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/PagamentoController.java
@@ -31,7 +31,7 @@ import java.util.List; // Necessário se for manter o método listarTodos sem pa
 
 @RestController
 @RequestMapping("/rest/pagamentos")
-@CrossOrigin(origins = "*") // Ajuste em produção!
+// @CrossOrigin(origins = "*") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Pagamentos (Simulado)", description = "Operações para registro e consulta de pagamentos simulados (controle interno).") // <<< TAG
 public class PagamentoController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/PecasController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/PecasController.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/rest/pecas")
-@CrossOrigin(origins = "http://localhost:3000")
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Peças", description = "Operações relacionadas a peças de veículos") // <<< TAG ADICIONADA
 public class PecasController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/RelatorioController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/RelatorioController.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/rest/relatorios")
-@CrossOrigin(origins = "http://localhost:3000") // Ajuste para sua URL de frontend
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Relatórios", description = "Endpoints para geração de relatórios consolidados")
 public class RelatorioController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/VeiculoController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/VeiculoController.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/rest/veiculo") // Mantendo o path base original
-@CrossOrigin(origins = "http://localhost:3000") // Ajuste se necessário
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 @Tag(name = "Veículos", description = "Operações relacionadas a veículos e seu histórico de serviços") // Tag atualizada
 public class VeiculoController {
 

--- a/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/auth/AuthController.java
+++ b/projeto-semestral/projeto-semestral/src/main/java/br/com/fiap/controller/auth/AuthController.java
@@ -20,7 +20,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.CrossOrigin; // Importe CrossOrigin
+// import org.springframework.web.bind.annotation.CrossOrigin; // Comentado ou Removido
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,7 +31,7 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/auth") // Prefixo para endpoints de autenticação
 @Tag(name = "Autenticação", description = "Gerenciamento de usuários e login com JWT") // Atualize a descrição
-@CrossOrigin(origins = "http://localhost:3000") // ADICIONADO: Permite requisições do seu frontend Next.js
+// @CrossOrigin(origins = "http://localhost:3000") // REMOVIDO: A configuração global de CORS em SecurityConfig será usada
 public class AuthController {
 
     private static final Logger log = LoggerFactory.getLogger(AuthController.class);


### PR DESCRIPTION
Removed @CrossOrigin annotations from individual Spring MVC controllers. This change centralizes the CORS policy within the global configuration defined in `SecurityConfig.java` using `http.cors()`.

The global configuration already permitted access from origins such as 'http://localhost:3000' and 'http://172.16.72.110:3000'. The controller-level annotations were more restrictive (often only allowing 'http://localhost:3000'), potentially overriding the global policy and causing CORS errors when your frontend was accessed from other allowed origins like 'http://172.16.72.110:3000'.

This change ensures a single source of truth for CORS policy, resolving the conflicts and allowing all origins defined in `SecurityConfig` to correctly access the API endpoints. No changes were made to your frontend, as the issue was determined to be with the backend's CORS handling.